### PR TITLE
Fix template link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Status Improvement Proposals (SIPs) describe standards for the Status platform, including core protocol specifications, client APIs, and contract standards.
 
 # Contributing
-First review [SIP-1](SIPS/eip-1.md). Then clone the repository and add your SIP to it. There is a [template SIP here](eip-X.md). Then submit a Pull Request to Status's [SIPs repository](https://github.com/status-im/SIPs).
+First review [SIP-1](SIPS/eip-1.md). Then clone the repository and add your SIP to it. There is a [template SIP here](sip-X.md). Then submit a Pull Request to Status's [SIPs repository](https://github.com/status-im/SIPs).
 
 # SIP status terms
 * **Draft** - an SIP that is open for consideration


### PR DESCRIPTION
It was still linked to `eip-X.md`